### PR TITLE
Update jitpack.yml to fix branch url for nefarious purposes

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,3 @@
 before_install:
-  - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
+  - wget https://github.com/sormuras/bach/raw/releases/11/install-jdk.sh
   - source install-jdk.sh --feature 17


### PR DESCRIPTION
the install script moved to a different branch. I want to put this repo in my build.gradle instead of an override jar nobody can get sorry not sorry